### PR TITLE
implement functions to augment the context

### DIFF
--- a/changelog/unreleased/fix-context-handling.md
+++ b/changelog/unreleased/fix-context-handling.md
@@ -1,0 +1,6 @@
+Bugfix: Fix usage of context.Context 
+
+The context was filled with a key defined in the package service but read with a key from the package imgsource.
+Since `service.key` and `imgsource.key` are different types imgsource could not read the value provided by service.
+
+https://github.com/owncloud/ocis-thumbnails/issues/18

--- a/go.sum
+++ b/go.sum
@@ -455,7 +455,7 @@ github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukw
 github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014/go.mod h1:joRatxRJaZBsY3JAOEMcoOp05CnZzsx4scTxi95DHyQ=
 github.com/owncloud/ocis-pkg/v2 v2.2.1 h1:LK7WxHYugEFQ9NHTOz0EP8DRjbt51wXhyqruV03z6zI=
 github.com/owncloud/ocis-pkg/v2 v2.2.1/go.mod h1:MXv7QzsYsu4YWuyJxhq1kLLmJa/r5gbqHe1FXulMHaw=
-ithub.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
+github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -11,12 +11,6 @@ import (
 	"github.com/owncloud/ocis-thumbnails/pkg/thumbnail/resolution"
 )
 
-type contextKey string
-
-const (
-	authorization contextKey = imgsource.WebDavAuth
-)
-
 // NewService returns a service implementation for Service.
 func NewService(opts ...Option) v0proto.ThumbnailServiceHandler {
 	options := newOptions(opts...)
@@ -68,7 +62,7 @@ func (g Thumbnail) GetThumbnail(ctx context.Context, req *v0proto.GetRequest, rs
 	}
 
 	auth := req.Authorization
-	sCtx := context.WithValue(ctx, authorization, auth)
+	sCtx := imgsource.WithAuthorization(ctx, auth)
 	img, err := g.source.Get(sCtx, tr.ImagePath)
 	if err != nil {
 		return err

--- a/pkg/thumbnail/imgsource/imgsource.go
+++ b/pkg/thumbnail/imgsource/imgsource.go
@@ -5,7 +5,26 @@ import (
 	"image"
 )
 
+type key int
+
+const (
+	auth key = iota
+)
+
 // Source defines the interface for image sources
 type Source interface {
 	Get(ctx context.Context, path string) (image.Image, error)
+}
+
+// WithAuthorization puts the authorization in the context.
+func WithAuthorization(parent context.Context, authorization string) context.Context {
+	return context.WithValue(parent, auth, authorization)
+}
+
+func authorization(ctx context.Context) string {
+	val := ctx.Value(auth)
+	if val == nil {
+		return ""
+	}
+	return val.(string)
 }

--- a/pkg/thumbnail/imgsource/webdav.go
+++ b/pkg/thumbnail/imgsource/webdav.go
@@ -23,11 +23,6 @@ type WebDav struct {
 	baseURL string
 }
 
-const (
-	// WebDavAuth is the parameter name for the autorization token
-	WebDavAuth = "Authorization"
-)
-
 // Get downloads the file from a webdav service
 func (s WebDav) Get(ctx context.Context, file string) (image.Image, error) {
 	u, _ := url.Parse(s.baseURL)
@@ -37,8 +32,8 @@ func (s WebDav) Get(ctx context.Context, file string) (image.Image, error) {
 		return nil, fmt.Errorf("could not get the image \"%s\" error: %s", file, err.Error())
 	}
 
-	auth, ok := authorization(ctx)
-	if !ok {
+	auth := authorization(ctx)
+	if auth == "" {
 		return nil, fmt.Errorf("could not get image \"%s\" error: authorization is missing", file)
 	}
 	req.Header.Add("Authorization", auth)
@@ -58,9 +53,4 @@ func (s WebDav) Get(ctx context.Context, file string) (image.Image, error) {
 		return nil, fmt.Errorf("could not decode the image \"%s\". error: %s", file, err.Error())
 	}
 	return img, nil
-}
-
-func authorization(ctx context.Context) (string, bool) {
-	auth, ok := ctx.Value(WebDavAuth).(string)
-	return auth, ok
 }


### PR DESCRIPTION
Fixes #18 
The context was filled with a key defined in the package service but read with a key from the package imgsource.
Since `service.key` and `imgsource.key` are different types imgsource could not read the value provided by service.