### PR TITLE
use micros service error api

### DIFF
--- a/changelog/unreleased/use-micro-error-api.md
+++ b/changelog/unreleased/use-micro-error-api.md
@@ -1,0 +1,5 @@
+Change: use micro service error api
+
+The service now also returns a status code when an error occurs.
+
+https://github.com/owncloud/ocis-thumbnails/issues/31


### PR DESCRIPTION
First part of getting rid of the annoying warnings when a file has an unsupported type.
The other part must be implemented in ocis-webdav when this pr was merged.
