### PR TITLE
Use the ocis-proxy URL to make sure auth works correctly

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ THUMBNAILS_FILESYSTEMSTORAGE_ROOT
 : Root path of the filesystem storage directory, defaults to `<os tempdir>/ocis-thumbnails/`
 
 THUMBNAILS_WEBDAVSOURCE_BASEURL
-: Base url for a webdav api, defaults to `htp://localhost:9140/remote.php/webdav/`
+: Base url for a webdav api, defaults to `https://localhost:9200/remote.php/webdav/`
 
 THUMBNAILS_RESOLUTIONS
 : List of resolutions supported by the service, defaults to `["16x16", "32x32", "64x64", "128x128"]
@@ -155,7 +155,7 @@ If you prefer to configure the service with commandline flags you can see the av
 : Root path of the filesystem storage directory, defaults to `<os tempdir>/ocis-thumbnails/`
 
 --webdavsource-baseurl
-: Base url for a webdav api, defaults to `htp://localhost:9140/remote.php/webdav/`
+: Base url for a webdav api, defaults to `https://localhost:9200/remote.php/webdav/`
 
 --thumbnail-resolution
 : List of resolutions supported by the service, defaults to `["16x16", "32x32", "64x64", "128x128"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,8 @@ type FileSystemStorage struct {
 
 // WebDavSource defines the available webdav source configuration.
 type WebDavSource struct {
-	BaseURL string
+	BaseURL  string
+	Insecure bool
 }
 
 // FileSystemSource defines the available filesystem source configuration.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -153,6 +153,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"THUMBNAILS_WEBDAVSOURCE_BASEURL"},
 			Destination: &cfg.Thumbnail.WebDavSource.BaseURL,
 		},
+		&cli.BoolFlag{
+			Name:        "webdavsource-insecure",
+			Value:       true,
+			Usage:       "Whether to skip certificate checks",
+			EnvVars:     []string{"THUMBNAILS_WEBDAVSOURCE_INSECURE"},
+			Destination: &cfg.Thumbnail.WebDavSource.Insecure,
+		},
 		&cli.StringSliceFlag{
 			Name:    "thumbnail-resolution",
 			Value:   cli.NewStringSlice("16x16", "32x32", "64x64", "128x128", "1920x1080", "3840x2160", "7680x4320"),

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -148,7 +148,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "webdavsource-baseurl",
-			Value:       "http://localhost:9140/remote.php/webdav/",
+			Value:       "https://localhost:9200/remote.php/webdav/",
 			Usage:       "Base url for a webdav api",
 			EnvVars:     []string{"THUMBNAILS_WEBDAVSOURCE_BASEURL"},
 			Destination: &cfg.Thumbnail.WebDavSource.BaseURL,

--- a/pkg/thumbnail/imgsource/webdav.go
+++ b/pkg/thumbnail/imgsource/webdav.go
@@ -2,6 +2,7 @@ package imgsource
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"image"
 	"net/http"
@@ -27,12 +28,17 @@ type WebDav struct {
 func (s WebDav) Get(ctx context.Context, file string) (image.Image, error) {
 	u, _ := url.Parse(s.baseURL)
 	u.Path = path.Join(u.Path, file)
+	fmt.Printf("url: %s", u.String())
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the image \"%s\" error: %s", file, err.Error())
 	}
 
+	// FIXME: make this configurable!!
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
 	auth := authorization(ctx)
+	fmt.Printf("auth: %s", auth)
 	if auth == "" {
 		return nil, fmt.Errorf("could not get image \"%s\" error: authorization is missing", file)
 	}

--- a/pkg/thumbnail/imgsource/webdav.go
+++ b/pkg/thumbnail/imgsource/webdav.go
@@ -15,30 +15,29 @@ import (
 // NewWebDavSource creates a new webdav instance.
 func NewWebDavSource(cfg config.WebDavSource) WebDav {
 	return WebDav{
-		baseURL: cfg.BaseURL,
+		baseURL:  cfg.BaseURL,
+		insecure: cfg.Insecure,
 	}
 }
 
 // WebDav implements the Source interface for webdav services
 type WebDav struct {
-	baseURL string
+	baseURL  string
+	insecure bool
 }
 
 // Get downloads the file from a webdav service
 func (s WebDav) Get(ctx context.Context, file string) (image.Image, error) {
 	u, _ := url.Parse(s.baseURL)
 	u.Path = path.Join(u.Path, file)
-	fmt.Printf("url: %s", u.String())
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the image \"%s\" error: %s", file, err.Error())
 	}
 
-	// FIXME: make this configurable!!
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: s.insecure}
 
 	auth := authorization(ctx)
-	fmt.Printf("auth: %s", auth)
 	if auth == "" {
 		return nil, fmt.Errorf("could not get image \"%s\" error: authorization is missing", file)
 	}


### PR DESCRIPTION
Since a recent change in ocis-accounts that makes a distinction between
user id and user name, the thumbnails cannot properly authenticate
against the Reva API endpoint (port 9140) using the provided Bearer
token.

Since the ocis-proxy is handling authentication correctly, the default
setting has been changed here to connect to ocis-proxy.

