### PR TITLE
add command to list versions of running thumbnails service instances

### DIFF
--- a/changelog/unreleased/add-version-command.md
+++ b/changelog/unreleased/add-version-command.md
@@ -1,0 +1,6 @@
+Enhancement: Add version command
+
+Added a command to print the versions of all running ocis-thumbnails service instances.
+Also added an entry in the metrics which shows build information like the version.
+
+https://github.com/owncloud/product/issues/226

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/ogier/pflag v0.0.1
 	github.com/oklog/run v1.0.0
+	github.com/olekukonko/tablewriter v0.0.1
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/owncloud/ocis-pkg/v2 v2.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,7 @@ github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFP
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -32,12 +32,14 @@ func Execute() error {
 		Flags: flagset.RootWithConfig(cfg),
 
 		Before: func(c *cli.Context) error {
+			cfg.Server.Version = version.String
 			return ParseConfig(c, cfg)
 		},
 
 		Commands: []*cli.Command{
 			Server(cfg),
 			Health(cfg),
+			PrintVersion(cfg),
 		},
 	}
 

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -128,6 +128,8 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
+			metrics.BuildInfo.WithLabelValues(cfg.Server.Version).Set(1)
+
 			service := grpc.NewService(
 				grpc.Logger(logger),
 				grpc.Context(ctx),

--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -1,0 +1,45 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/micro/cli/v2"
+	"github.com/micro/go-micro/v2/registry/mdns"
+	tw "github.com/olekukonko/tablewriter"
+	"github.com/owncloud/ocis-thumbnails/pkg/config"
+	"github.com/owncloud/ocis-thumbnails/pkg/flagset"
+)
+
+// PrintVersion prints the service versions of all running instances.
+func PrintVersion(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Print the versions of the running instances",
+		Flags: flagset.ListThumbnailsWithConfig(cfg),
+		Action: func(c *cli.Context) error {
+			reg := mdns.NewRegistry()
+			services, err := reg.GetService(cfg.Server.Namespace + "." + cfg.Server.Name)
+			if err != nil {
+				fmt.Println(fmt.Errorf("could not get thumbnails services from the registry: %v", err))
+				return err
+			}
+
+			if len(services) == 0 {
+				fmt.Println("No running thumbnails service found.")
+				return nil
+			}
+
+			table := tw.NewWriter(os.Stdout)
+			table.SetHeader([]string{"Version", "Address", "Id"})
+			table.SetAutoFormatHeaders(false)
+			for _, s := range services {
+				for _, n := range s.Nodes {
+					table.Append([]string{s.Version, n.Address, n.Id})
+				}
+			}
+			table.Render()
+			return nil
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ type Server struct {
 	Name      string
 	Namespace string
 	Address   string
+	Version   string
 }
 
 // Tracing defines the available tracing configuration.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -168,3 +168,23 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 	}
 }
+
+// ListThumbnailsWithConfig applies the config to the flagset for listing thumbnails services.
+func ListThumbnailsWithConfig(cfg *config.Config) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        "grpc-name",
+			Value:       "thumbnails",
+			Usage:       "Name of the service",
+			EnvVars:     []string{"THUMBNAILS_GRPC_NAME"},
+			Destination: &cfg.Server.Name,
+		},
+		&cli.StringFlag{
+			Name:        "grpc-namespace",
+			Value:       "com.owncloud.api",
+			Usage:       "Set the base namespace for the grpc namespace",
+			EnvVars:     []string{"THUMBNAILS_GRPC_NAMESPACE"},
+			Destination: &cfg.Server.Namespace,
+		},
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,9 +12,10 @@ var (
 
 // Metrics defines the available metrics of this service.
 type Metrics struct {
-	Counter  *prometheus.CounterVec
-	Latency  *prometheus.SummaryVec
-	Duration *prometheus.HistogramVec
+	Counter   *prometheus.CounterVec
+	Latency   *prometheus.SummaryVec
+	Duration  *prometheus.HistogramVec
+	BuildInfo *prometheus.GaugeVec
 }
 
 // New initializes the available metrics.
@@ -38,6 +39,12 @@ func New() *Metrics {
 			Name:      "getthumbnail_duration_seconds",
 			Help:      "GetThumbnail method requests time in seconds",
 		}, []string{}),
+		BuildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "build_info",
+			Help:      "Build information",
+		}, []string{"version"}),
 	}
 
 	_ = prometheus.Register(
@@ -50,6 +57,10 @@ func New() *Metrics {
 
 	_ = prometheus.Register(
 		m.Duration,
+	)
+
+	_ = prometheus.Register(
+		m.BuildInfo,
 	)
 
 	return m

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/owncloud/ocis-pkg/v2/service/debug"
 	"github.com/owncloud/ocis-thumbnails/pkg/config"
-	"github.com/owncloud/ocis-thumbnails/pkg/version"
 )
 
 // Server initializes the debug service and server.
@@ -16,7 +15,7 @@ func Server(opts ...Option) (*http.Server, error) {
 	return debug.NewService(
 		debug.Logger(options.Logger),
 		debug.Name(options.Config.Server.Name),
-		debug.Version(version.String),
+		debug.Version(options.Config.Server.Version),
 		debug.Address(options.Config.Debug.Addr),
 		debug.Token(options.Config.Debug.Token),
 		debug.Pprof(options.Config.Debug.Pprof),

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -21,6 +21,7 @@ func NewService(opts ...Option) grpc.Service {
 		grpc.Address(options.Address),
 		grpc.Context(options.Context),
 		grpc.Flags(options.Flags...),
+		grpc.Version(options.Config.Server.Version),
 	)
 
 	var thumbnail proto.ThumbnailServiceHandler


### PR DESCRIPTION
Added a command to print the versions of all running ocis-thumbnails service instances.
Also added an entry in the metrics which shows build information like the version.